### PR TITLE
Move incompatible rustflags to Cargo.toml

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,9 +1,5 @@
 [target.thumbv7em-none-eabi]
 runner = 'arm-none-eabi-gdb'
-rustflags = [
-  "-C", "lto",
-  "-C", "link-arg=-Tlink.x",
-]
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ cortex-m-rt = {version = "0.6.11", features = [ "device" ] }
 stm32f3 = { version = "0.9.0", features = [ "stm32f303", "rt" ] }
 stm32f3xx-hal = { version = "0.4.0", features = [ "stm32f303xc", "rt", "stm32-usbd" ] }
 stm32-usbd = { version = "0.5.0", features = ["ram_access_1x16"] }
+
+[profile.release]
+lto = "fat"
+opt-level = "z"
+codegen-units = 1


### PR DESCRIPTION
Otherwise:

```
$ git clone https://github.com/agalakhov/usbd-hid-device-example.git
Cloning into 'usbd-hid-device-example'...
remote: Enumerating objects: 16, done.
remote: Counting objects: 100% (16/16), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 16 (delta 0), reused 16 (delta 0), pack-reused 0
Unpacking objects: 100% (16/16), 12.11 KiB | 539.00 KiB/s, done.

$ cargo build --release
  Downloaded generic-array v0.11.1
  Downloaded cortex-m-rt-macros v0.1.7
  Downloaded usbd-hid-device v0.1.0
  Downloaded usb-device v0.2.3
  Downloaded stm32-usbd v0.5.0
  Downloaded stm32f3xx-hal v0.4.0
  Downloaded lsm303dlhc v0.2.0
  Downloaded cortex-m-rt v0.6.11
  Downloaded stm32f3 v0.9.0
  Downloaded 9 crates (2.7 MB) in 4.62s (largest was `stm32f3` at 2.5 MB)
   Compiling semver-parser v0.7.0
   Compiling typenum v1.11.2
   Compiling cortex-m v0.6.1
   Compiling stable_deref_trait v1.1.1
error: options `-C embed-bitcode=no` and `-C lto` are incompatible

error: could not compile `stable_deref_trait`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
$ rustc --version
rustc 1.47.0-nightly (d6953df14 2020-07-25)
```